### PR TITLE
Remove pointer initializations

### DIFF
--- a/github/github.go
+++ b/github/github.go
@@ -61,7 +61,7 @@ func CreateGithubMilestoneMap(githubAPI []githubAPI) map[string]utils.Milestone 
 
 func paginate(URL string, token string) ([][]byte, error) {
 	apiData := make([][]byte, 1)
-	client := &http.Client{}
+	client := http.Client{}
 	paginate := true
 	for paginate == true {
 		paginate = false
@@ -120,7 +120,7 @@ func ReactivateClosedMilestones(
 	token string,
 	project string,
 ) (map[string]utils.Milestone, error) {
-	client := &http.Client{}
+	client := http.Client{}
 	var strURL []string
 	for _, v := range milestones {
 		milestoneID := strconv.Itoa(v.Number)
@@ -185,7 +185,7 @@ func getMilestones(baseURL string, token string, project string, state string) (
 }
 
 func createMilestones(baseURL string, token string, project string, milestones map[string]utils.Milestone) error {
-	client := &http.Client{}
+	client := http.Client{}
 	var strURL []string
 	strURL = []string{baseURL, project, "/milestones"}
 	URL := strings.Join(strURL, "")

--- a/gitlab/gitlab.go
+++ b/gitlab/gitlab.go
@@ -98,7 +98,7 @@ func createGitlabMilestoneMap(gitlabAPI []gitlabAPI) map[string]utils.Milestone 
 
 func paginate(URL string, token string) ([][]byte, error) {
 	apiData := make([][]byte, 1)
-	client := &http.Client{}
+	client := http.Client{}
 	paginate := true
 	for paginate == true {
 		paginate = false
@@ -157,7 +157,7 @@ func ReactivateClosedMilestones(
 	project string,
 	logger *log.Logger,
 ) (map[string]utils.Milestone, error) {
-	client := &http.Client{}
+	client := http.Client{}
 	var strURL []string
 	for _, v := range milestones {
 		milestoneID := v.ID
@@ -216,7 +216,7 @@ func getMilestones(baseURL string, token string, project string, state string) (
 }
 
 func createMilestones(baseURL string, token string, project string, milestones map[string]utils.Milestone) error {
-	client := &http.Client{}
+	client := http.Client{}
 	var strURL []string
 	strURL = []string{baseURL, "/projects/", project, "/milestones"}
 	URL := strings.Join(strURL, "")

--- a/main.go
+++ b/main.go
@@ -45,8 +45,8 @@ func checkAPI(baseURL string, token string, namespace string, project string) (s
 		"gitlab": gitlabURL,
 		"github": githubURL,
 	}
-	resp := &http.Response{}
-	client := &http.Client{}
+	var resp http.Response
+	var client http.Client
 	for k, v := range m {
 		req, err := http.NewRequest("GET", v, nil)
 		if err != nil {
@@ -59,7 +59,7 @@ func checkAPI(baseURL string, token string, namespace string, project string) (s
 			req.Header.Add("Accept", "application/vnd.github.inertia-preview+json")
 			req.Header.Add("Authorization", "token "+token)
 		}
-		resp, err = client.Do(req)
+		resp, err := client.Do(req)
 		if err != nil {
 			return "", err
 		}

--- a/main.go
+++ b/main.go
@@ -45,7 +45,7 @@ func checkAPI(baseURL string, token string, namespace string, project string) (s
 		"gitlab": gitlabURL,
 		"github": githubURL,
 	}
-	var resp http.Response
+	var resp *http.Response
 	var client http.Client
 	for k, v := range m {
 		req, err := http.NewRequest("GET", v, nil)
@@ -59,7 +59,7 @@ func checkAPI(baseURL string, token string, namespace string, project string) (s
 			req.Header.Add("Accept", "application/vnd.github.inertia-preview+json")
 			req.Header.Add("Authorization", "token "+token)
 		}
-		resp, err := client.Do(req)
+		resp, err = client.Do(req)
 		if err != nil {
 			return "", err
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:
Removes pointers when initializing the http.Response and http.Client structs so that we aren't hiding that something is giving pointers within those variables.

**Which issue this PR fixes**:
fixes #54 