### PR TITLE
Refactor pagination functions and tests

### DIFF
--- a/github/github.go
+++ b/github/github.go
@@ -99,7 +99,7 @@ func ReactivateClosedMilestones(
 		if err != nil {
 			return nil, err
 		}
-		req.Header.Add("Accept", "application/vnd.github.inertia-preview+json")
+		req.Header.Add("Accept", "application/vnd.github.v3+json")
 		req.Header.Add("Authorization", "token "+token)
 		resp, err := client.Do(req)
 		if err != nil {
@@ -165,7 +165,7 @@ func createMilestones(baseURL string, token string, project string, milestones m
 		if err != nil {
 			return err
 		}
-		req.Header.Add("Accept", "application/vnd.github.inertia-preview+json")
+		req.Header.Add("Accept", "application/vnd.github.v3+json")
 		req.Header.Add("Authorization", "token "+token)
 		resp, err := client.Do(req)
 		if err != nil {

--- a/github/github.go
+++ b/github/github.go
@@ -128,8 +128,7 @@ func getMilestones(baseURL string, token string, project string, state string) (
 	q.Set("state", state)
 	u.RawQuery = q.Encode()
 	newURL = u.String()
-	api := "github"
-	apiData, err := utils.Paginate(newURL, api, token)
+	apiData, err := utils.Paginate(newURL, "gitlab", token)
 	if err != nil {
 		return nil, err
 	}

--- a/github/github_test.go
+++ b/github/github_test.go
@@ -41,26 +41,6 @@ func TestGithubCreateAndDisplayNewMilestones(t *testing.T) {
 	}
 }
 
-func TestPaginate(t *testing.T) {
-	httpmock.Activate()
-	defer httpmock.DeactivateAndReset()
-	pages := MockPaginate("https://example.com")
-	apiData, err := paginate("https://example.com", "token")
-	if err != nil {
-		t.Error(err)
-	}
-	if len(apiData) != pages {
-		t.Errorf("Expected %d, got %d", pages, len(apiData))
-	}
-}
-
-func TestPaginateFailWhenURLisWrong(t *testing.T) {
-	_, err := paginate("https://example.c_m", "token")
-	if err == nil {
-		t.Errorf("Expected to get an error when url is wrong")
-	}
-}
-
 func TestGetActiveMilestones(t *testing.T) {
 	httpmock.Activate()
 	defer httpmock.DeactivateAndReset()

--- a/github/testing.go
+++ b/github/testing.go
@@ -99,34 +99,3 @@ func MockGithubAPIPatchRequest(URL string, state string, id string) {
 		},
 	)
 }
-
-// MockPaginate creates a mock responder to return a byte slice
-func MockPaginate(url string) int {
-	linkHeader := []string{
-		"<http://example.com/page=1>; rel=\"next\", <http://example.com/page=3>; rel=\"last\"",
-		"<http://example.com/page=3>; rel=\"next\", <http://example.com/page=3>; rel=\"last\"",
-		"<http://example.com/page=2>; rel=\"first\", <http://example.com/page=3>; rel=\"last\"",
-	}
-	links := []string{
-		"http://example.com/page=1",
-		"http://example.com/page=3",
-		"http://example.com/page=2",
-	}
-	for i, link := range linkHeader {
-		httpmock.RegisterResponder("GET", links[i],
-			func(req *http.Request) (*http.Response, error) {
-				resp := httpmock.NewStringResponse(200, "testing")
-				resp.Header.Set("Link", link)
-				return resp, nil
-			},
-		)
-	}
-	httpmock.RegisterResponder("GET", url,
-		func(req *http.Request) (*http.Response, error) {
-			resp := httpmock.NewStringResponse(200, "testing")
-			resp.Header.Set("Link", linkHeader[0])
-			return resp, nil
-		},
-	)
-	return len(linkHeader)
-}

--- a/gitlab/gitlab.go
+++ b/gitlab/gitlab.go
@@ -58,8 +58,7 @@ func GetProjectID(baseURL string, token string, projectname string, namespace st
 	q := u.Query()
 	q.Set("search", projectname)
 	u.RawQuery = q.Encode()
-	api := "gitlab"
-	apiData, err := utils.Paginate(u.String(), api, token)
+	apiData, err := utils.Paginate(u.String(), "gitlab", token)
 	if err != nil {
 		return "", err
 	}
@@ -161,8 +160,7 @@ func getMilestones(baseURL string, token string, project string, state string) (
 	q.Set("state", state)
 	u.RawQuery = q.Encode()
 	newURL = u.String()
-	api := "gitlab"
-	apiData, err := utils.Paginate(newURL, api, token)
+	apiData, err := utils.Paginate(newURL, "gitlab", token)
 	if err != nil {
 		return nil, err
 	}

--- a/main.go
+++ b/main.go
@@ -56,7 +56,7 @@ func checkAPI(baseURL string, token string, namespace string, project string) (s
 		case "gitlab":
 			req.Header.Add("PRIVATE-TOKEN", token)
 		case "github":
-			req.Header.Add("Accept", "application/vnd.github.inertia-preview+json")
+			req.Header.Add("Accept", "application/vnd.github.v3+json")
 			req.Header.Add("Authorization", "token "+token)
 		}
 		resp, err = client.Do(req)


### PR DESCRIPTION
**What this PR does / why we need it**:
Refactors the pagination functions since they currently exist in both the github and gitlab packages. This pull request moves the pagination function to the utils package and adds a switch statement for the API-specific request headers that are needed. Also moves the pagination test functions to the utils package and updates the GitHub Accept headers to the current version.

**Which issue this PR fixes**:
fixes #57 